### PR TITLE
Migrate to Simplifile

### DIFF
--- a/birdie_snapshots/inline_object_schema_test.accepted
+++ b/birdie_snapshots/inline_object_schema_test.accepted
@@ -11,7 +11,7 @@ import gleam/dynamic
 import gleam/dynamic/decode
 
 pub type User {
-  User(active: Option(Bool), name: Option(String), age: Option(Int))
+  User(active: Option(Bool), age: Option(Int), name: Option(String))
 }
 
 pub fn user_decoder() {
@@ -20,17 +20,17 @@ pub fn user_decoder() {
     None,
     decode.optional(decode.bool),
   )
-  use name <- decode.optional_field("name", None, decode.optional(decode.string))
   use age <- decode.optional_field("age", None, decode.optional(decode.int))
-  decode.success(User(active: active, name: name, age: age))
+  use name <- decode.optional_field("name", None, decode.optional(decode.string))
+  decode.success(User(active: active, age: age, name: name))
 }
 
 pub fn user_encode(data: User) {
   json.object(
     [
       #("active", json.nullable(data.active, json.bool)),
-      #("name", json.nullable(data.name, json.string)),
-      #("age", json.nullable(data.age, json.int))
+      #("age", json.nullable(data.age, json.int)),
+      #("name", json.nullable(data.name, json.string))
     ],
   )
 }

--- a/birdie_snapshots/ref_object_schema_test.accepted
+++ b/birdie_snapshots/ref_object_schema_test.accepted
@@ -17,14 +17,6 @@ pub type User {
 pub type Fullname =
   String
 
-pub fn fullname_decoder() {
-  decode.string
-}
-
-pub fn fullname_encode(data: Fullname) {
-  json.string(data)
-}
-
 pub fn user_decoder() {
   use name <- decode.field("name", fullname_decoder())
   decode.success(User(name: name))
@@ -32,4 +24,12 @@ pub fn user_decoder() {
 
 pub fn user_encode(data: User) {
   json.object([#("name", fullname_encode(data.name))])
+}
+
+pub fn fullname_decoder() {
+  decode.string
+}
+
+pub fn fullname_encode(data: Fullname) {
+  json.string(data)
 }

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,5 @@
 name = "oas_generator"
 version = "1.2.1"
-target = "javascript"
 description = "Generate HTTP clients from Open API specs."
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "crowdhailer", repo = "oas_generator" }
@@ -11,10 +10,11 @@ gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 glance = ">= 3.0.0 and < 4.0.0"
 gleam_http = ">= 3.7.2 and < 4.0.0"
 justin = ">= 1.0.1 and < 2.0.0"
-midas_node = ">= 1.2.5 and < 2.0.0"
-snag = ">= 1.1.0 and < 2.0.0"
 oas = ">= 2.1.0 and < 3.0.0"
 glance_printer = ">= 3.0.0 and < 4.0.0"
+simplifile = ">= 2.2.1 and < 3.0.0"
+gleam_json = ">= 2.3.0 and < 3.0.0"
+snag = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,7 +4,6 @@
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
   { name = "birdie", version = "1.2.7", build_tools = ["gleam"], requirements = ["argv", "edit_distance", "filepath", "glance", "gleam_community_ansi", "gleam_erlang", "gleam_stdlib", "justin", "rank", "simplifile", "term_size", "trie_again"], otp_app = "birdie", source = "hex", outer_checksum = "F9EFE5AD3F61E840CB7D4F6C88121CF7CCE5F89B74828ED86BD90F61E69CA80D" },
-  { name = "conversation", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_javascript", "gleam_stdlib"], otp_app = "conversation", source = "hex", outer_checksum = "103DF47463B8432AB713D6643DC17244B9C82E2B172A343150805129FE584A2F" },
   { name = "edit_distance", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "edit_distance", source = "hex", outer_checksum = "A1E485C69A70210223E46E63985FA1008B8B2DDA9848B7897469171B29020C05" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "glam", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "4932A2D139AB0389E149396407F89654928D7B815E212BB02F13C66F53B1BBA1" },
@@ -13,26 +12,15 @@ packages = [
   { name = "gleam_community_ansi", version = "1.4.3", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "8A62AE9CC6EA65BEA630D95016D6C07E4F9973565FA3D0DE68DC4200D8E0DD27" },
   { name = "gleam_community_colour", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "FDD6AC62C6EC8506C005949A4FCEF032038191D5EAAEC3C9A203CD53AE956ACA" },
   { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_fetch", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_javascript", "gleam_stdlib"], otp_app = "gleam_fetch", source = "hex", outer_checksum = "2CBF9F2E1C71AEBBFB13A9D5720CD8DB4263EB02FE60C5A7A1C6E17B0151C20C" },
   { name = "gleam_http", version = "3.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8A70D2F70BB7CFEB5DF048A2183FFBA91AF6D4CF5798504841744A16999E33D2" },
-  { name = "gleam_javascript", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "EF6C77A506F026C6FB37941889477CD5E4234FCD4337FF0E9384E297CB8F97EB" },
   { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
-  { name = "gleam_package_interface", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_package_interface", source = "hex", outer_checksum = "80D8B1842ACC6CF50E53FF1B220FF57E2B3A60FAF19DD885EC683CDED64C2C52" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.59.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F8FEE9B35797301994B81AF75508CF87C328FE1585558B0FFD188DC2B32EAA95" },
   { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
-  { name = "glen", version = "2.2.2", build_tools = ["gleam"], requirements = ["conversation", "filepath", "gleam_community_ansi", "gleam_http", "gleam_javascript", "gleam_stdlib", "marceau"], otp_app = "glen", source = "hex", outer_checksum = "62DF8F8305650237B58B7F29C01016383950479D35FCD8393800CAB94675B0DE" },
-  { name = "glen_node", version = "0.0.3", build_tools = ["gleam"], requirements = ["gleam_javascript", "glen"], otp_app = "glen_node", source = "hex", outer_checksum = "0A81302C16B9719FC47FB022A127A51EA668D4F78CE6DCCCF430A3C098395511" },
   { name = "glexer", version = "2.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "5C235CBDF4DA5203AD5EAB1D6D8B456ED8162C5424FE2309CFFB7EF438B7C269" },
-  { name = "javascript_mutable_reference", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "javascript_mutable_reference", source = "hex", outer_checksum = "3EE953EE7FE4FAFD17C16F24184F4C832FE260D761753F28F20D4AC1DA080F03" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
-  { name = "marceau", version = "1.3.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "2D1C27504BEF45005F5DFB18591F8610FB4BFA91744878210BDC464412EC44E9" },
-  { name = "midas", version = "1.4.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_http", "gleam_json", "gleam_stdlib", "snag"], otp_app = "midas", source = "hex", outer_checksum = "5D0C9F924D527DCA35D818A2D87A1ED0923FA3CAF59976F1A2D1C970A30C9C07" },
-  { name = "midas_node", version = "1.2.6", build_tools = ["gleam"], requirements = ["filepath", "gleam_fetch", "gleam_http", "gleam_javascript", "gleam_json", "gleam_package_interface", "gleam_stdlib", "glen", "glen_node", "javascript_mutable_reference", "midas", "plinth", "shellout", "simplifile", "snag"], otp_app = "midas_node", source = "hex", outer_checksum = "B81500DEE4094612BC89D257CAF517AEE433B79D930EC9AF5381BE1B664F546B" },
   { name = "oas", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib"], otp_app = "oas", source = "hex", outer_checksum = "CC5C8C828271719CCFA135D3B8F92359E8934E99827223A9D74AC87A7CD9E56F" },
-  { name = "plinth", version = "0.5.9", build_tools = ["gleam"], requirements = ["conversation", "gleam_javascript", "gleam_json", "gleam_stdlib"], otp_app = "plinth", source = "hex", outer_checksum = "9684C5D768F99B34537B48B100509389C45D2E7C045426E93ACB250993611724" },
   { name = "rank", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "rank", source = "hex", outer_checksum = "5660E361F0E49CBB714CC57CC4C89C63415D8986F05B2DA0C719D5642FAD91C9" },
-  { name = "shellout", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "1BDC03438FEB97A6AF3E396F4ABEB32BECF20DF2452EC9A8C0ACEB7BDDF70B14" },
   { name = "simplifile", version = "2.2.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "C88E0EE2D509F6D86EB55161D631657675AA7684DAB83822F7E59EB93D9A60E3" },
   { name = "snag", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "7E9F06390040EB5FAB392CE642771484136F2EC103A92AE11BA898C8167E6E17" },
   { name = "term_size", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "term_size", source = "hex", outer_checksum = "D00BD2BC8FB3EBB7E6AE076F3F1FF2AC9D5ED1805F004D0896C784D06C6645F1" },
@@ -44,9 +32,10 @@ birdie = { version = ">= 1.2.7 and < 2.0.0" }
 glance = { version = ">= 3.0.0 and < 4.0.0" }
 glance_printer = { version = ">= 3.0.0 and < 4.0.0" }
 gleam_http = { version = ">= 3.7.2 and < 4.0.0" }
+gleam_json = { version = ">= 2.3.0 and < 3.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 justin = { version = ">= 1.0.1 and < 2.0.0" }
-midas_node = { version = ">= 1.2.5 and < 2.0.0" }
 oas = { version = ">= 2.1.0 and < 3.0.0" }
+simplifile = { version = ">= 2.2.1 and < 3.0.0" }
 snag = { version = ">= 1.1.0 and < 2.0.0" }


### PR DESCRIPTION
There are many dependencies related to Node (via midas_node). 

Having many dependencies brought by a lib can be problematic, it is common to run into dependency conflicts in Gleam, and the compiler doesn't explain the conflicts well.

`Simplifile` gives us cross target file handling. 

Thanks