### PR TITLE
Add stricter typing based on "format"?

### DIFF
--- a/birdie_snapshots/allof_named_test.accepted
+++ b/birdie_snapshots/allof_named_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: allof_named_test
-file: ./test/oas/generator_test.gleam
-test_name: allof_named_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/alway_field_pass_test.accepted
+++ b/birdie_snapshots/alway_field_pass_test.accepted
@@ -4,6 +4,7 @@ title: alway_field_pass_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: alway_field_pass_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/alway_pass_test.accepted
+++ b/birdie_snapshots/alway_pass_test.accepted
@@ -4,6 +4,7 @@ title: alway_pass_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: alway_pass_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/always_test.accepted
+++ b/birdie_snapshots/always_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: always_test
-file: ./test/oas/generator_test.gleam
-test_name: always_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/array_of_primitive_test.accepted
+++ b/birdie_snapshots/array_of_primitive_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: array_of_primitive_test
-file: ./test/oas/generator_test.gleam
-test_name: array_of_primitive_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/array_of_references_test.accepted
+++ b/birdie_snapshots/array_of_references_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: array_of_references_test
-file: ./test/oas/generator_test.gleam
-test_name: array_of_references_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/array_parameters_response_test.accepted
+++ b/birdie_snapshots/array_parameters_response_test.accepted
@@ -4,6 +4,7 @@ title: array_parameters_response_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: array_parameters_response_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/date_format_schema_test.accepted
+++ b/birdie_snapshots/date_format_schema_test.accepted
@@ -1,0 +1,27 @@
+---
+version: 1.3.0
+title: date format schema test
+---
+import gleam/option.{type Option, None}
+import oas/generator/utils
+import gleam/time/calendar
+import gleam/json
+import gleam/dynamic
+import gleam/dynamic/decode
+import gleam/dict
+
+pub type Event {
+  Event(date: calendar.Date, name: String)
+}
+
+pub fn event_decoder() {
+  use date <- decode.field("date", utils.date_decoder())
+  use name <- decode.field("name", decode.string)
+  decode.success(Event(date: date, name: name))
+}
+
+pub fn event_encode(data: Event) {
+  utils.object(
+    [#("date", utils.encode_date(data.date)), #("name", json.string(data.name))],
+  )
+}

--- a/birdie_snapshots/dictionary_request_test.accepted
+++ b/birdie_snapshots/dictionary_request_test.accepted
@@ -4,6 +4,7 @@ title: dictionary_request_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: dictionary_request_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/duplicate_anon_object_test.accepted
+++ b/birdie_snapshots/duplicate_anon_object_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: duplicate_anon_object_test
-file: ./test/oas/generator_test.gleam
-test_name: duplicate_anon_object_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/empty_object_is_dictionary_of_anything_test.accepted
+++ b/birdie_snapshots/empty_object_is_dictionary_of_anything_test.accepted
@@ -4,6 +4,7 @@ title: empty_object_is_dictionary_of_anything_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/empty_object_test.accepted
+++ b/birdie_snapshots/empty_object_test.accepted
@@ -4,6 +4,7 @@ title: empty_object_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/enum_of_strings_test.accepted
+++ b/birdie_snapshots/enum_of_strings_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: enum_of_strings_test
-file: ./test/oas/generator_test.gleam
-test_name: enum_of_strings_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/explicitly_no_additional_test.accepted
+++ b/birdie_snapshots/explicitly_no_additional_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: explicitly_no_additional_test
-file: ./test/oas/generator_test.gleam
-test_name: explicitly_no_additional_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/get_test.accepted
+++ b/birdie_snapshots/get_test.accepted
@@ -4,6 +4,7 @@ title: get_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: single_response_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/inline_object_schema_test.accepted
+++ b/birdie_snapshots/inline_object_schema_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: inline_object_schema_test
-file: ./test/oas/generator_test.gleam
-test_name: inline_object_schema_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/just_string_request_test.accepted
+++ b/birdie_snapshots/just_string_request_test.accepted
@@ -4,6 +4,7 @@ title: just_string_request_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: just_string_request_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/multiple_error_response_test.accepted
+++ b/birdie_snapshots/multiple_error_response_test.accepted
@@ -4,6 +4,7 @@ title: multiple_error_response_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: multiple_error_response_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/nested_array_of_primitive_test.accepted
+++ b/birdie_snapshots/nested_array_of_primitive_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: nested_array_of_primitive_test
-file: ./test/oas/generator_test.gleam
-test_name: nested_array_of_primitive_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/nested_dictionary_test.accepted
+++ b/birdie_snapshots/nested_dictionary_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: nested_dictionary_test
-file: ./test/oas/generator_test.gleam
-test_name: nested_dictionary_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/nested_object_in_response_test.accepted
+++ b/birdie_snapshots/nested_object_in_response_test.accepted
@@ -4,6 +4,7 @@ title: nested_object_in_response_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: nested_object_in_response_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/nested_object_request_test.accepted
+++ b/birdie_snapshots/nested_object_request_test.accepted
@@ -4,6 +4,7 @@ title: nested_object_request_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: nested_object_request_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/nested_object_test.accepted
+++ b/birdie_snapshots/nested_object_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: nested_object_test
-file: ./test/oas/generator_test.gleam
-test_name: nested_object_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/never_test.accepted
+++ b/birdie_snapshots/never_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: never_test
-file: ./test/oas/generator_test.gleam
-test_name: never_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/nil_alias_test.accepted
+++ b/birdie_snapshots/nil_alias_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: nil_alias_test
-file: ./test/oas/generator_test.gleam
-test_name: nil_alias_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/no_content_response.accepted
+++ b/birdie_snapshots/no_content_response.accepted
@@ -4,6 +4,7 @@ title: no_content_response
 file: ./test/oas/generator/operations_test.gleam
 test_name: no_content_response_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/nullable_fields_test.accepted
+++ b/birdie_snapshots/nullable_fields_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: nullable_fields_test
-file: ./test/oas/generator_test.gleam
-test_name: nullable_fields_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/object_and_additional_test.accepted
+++ b/birdie_snapshots/object_and_additional_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: object_and_additional_test
-file: ./test/oas/generator_test.gleam
-test_name: object_and_additional_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/object_request_test.accepted
+++ b/birdie_snapshots/object_request_test.accepted
@@ -4,6 +4,7 @@ title: object_request_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: object_request_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/pure_dictionary_test.accepted
+++ b/birdie_snapshots/pure_dictionary_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: pure_dictionary_test
-file: ./test/oas/generator_test.gleam
-test_name: pure_dictionary_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/ref_object_schema_test.accepted
+++ b/birdie_snapshots/ref_object_schema_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: ref_object_schema_test
-file: ./test/oas/generator_test.gleam
-test_name: ref_object_schema_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/request_body_named_test.accepted
+++ b/birdie_snapshots/request_body_named_test.accepted
@@ -4,6 +4,7 @@ title: request_body_named_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: request_body_named_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/required_fields_test.accepted
+++ b/birdie_snapshots/required_fields_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: required_fields_test
-file: ./test/oas/generator_test.gleam
-test_name: required_fields_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/simple_string_schema_test.accepted
+++ b/birdie_snapshots/simple_string_schema_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: simple string schema test
-file: ./test/oas/generator_test.gleam
-test_name: simple_string_schema_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/single_allof_test.accepted
+++ b/birdie_snapshots/single_allof_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: single_allof_test
-file: ./test/oas/generator_test.gleam
-test_name: single_allof_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/birdie_snapshots/single_inline_object_response_test.accepted
+++ b/birdie_snapshots/single_inline_object_response_test.accepted
@@ -4,6 +4,7 @@ title: single_inline_object_response_test
 file: ./test/oas/generator/operations_test.gleam
 test_name: single_inline_object_response_test
 ---
+import gleam/time/calendar
 import gleam/dict
 import gleam/bool
 import gleam/result

--- a/birdie_snapshots/unsupported_anyof_test.accepted
+++ b/birdie_snapshots/unsupported_anyof_test.accepted
@@ -1,11 +1,10 @@
 ---
 version: 1.3.0
 title: unsupported_anyof_test
-file: ./test/oas/generator_test.gleam
-test_name: unsupported_anyof_test
 ---
 import gleam/option.{type Option, None}
 import oas/generator/utils
+import gleam/time/calendar
 import gleam/json
 import gleam/dynamic
 import gleam/dynamic/decode

--- a/src/oas/generator.gleam
+++ b/src/oas/generator.gleam
@@ -817,6 +817,7 @@ pub fn gen_operations_and_top_files(spec: oas.Document, provider, exclude) {
     "gleam/result",
     "gleam/bool",
     "gleam/dict",
+    "gleam/time/calendar",
   ]
   let operations =
     glance.Module(
@@ -856,6 +857,7 @@ pub fn gen_schema_file(schemas) {
       glance.Definition([], glance.Import("gleam/dynamic/decode", None, [], [])),
       glance.Definition([], glance.Import("gleam/dynamic", None, [], [])),
       glance.Definition([], glance.Import("gleam/json", None, [], [])),
+      glance.Definition([], glance.Import("gleam/time/calendar", None, [], [])),
       glance.Definition([], glance.Import("oas/generator/utils", None, [], [])),
       glance.Definition(
         [],

--- a/src/oas/generator/lift.gleam
+++ b/src/oas/generator/lift.gleam
@@ -43,12 +43,13 @@ pub type Primitive {
   Integer
   Number
   String
+  Date
   Null
   Always
   Never
 }
 
-// Can totally manually pass in config i.e. encoded/decode or even name 
+// Can totally manually pass in config i.e. encoded/decode or even name
 // pub fn lift(schema) {
 //   do_lift(schema, [])
 // }
@@ -109,6 +110,7 @@ fn schema_to_string(schema) {
         Integer -> "Integer"
         Number -> "Number"
         String -> "String"
+        Date -> "Date"
         Null -> "Null"
         Always -> "Always"
         Never -> "Never"
@@ -169,6 +171,9 @@ pub fn do_lift(schema, acc) -> #(Top, Bool, List(_)) {
         castor.Boolean(nullable:, ..) -> #(Primitive(Boolean), nullable, acc)
         castor.Integer(nullable:, ..) -> #(Primitive(Integer), nullable, acc)
         castor.Number(nullable:, ..) -> #(Primitive(Number), nullable, acc)
+        castor.String(nullable:, format: Some("date"), ..) -> {
+          #(Primitive(Date), nullable, acc)
+        }
         castor.String(nullable:, ..) -> #(Primitive(String), nullable, acc)
         castor.Null(..) -> #(Primitive(Null), False, acc)
         castor.Array(nullable:, items:, ..) -> {

--- a/src/oas/generator/schema.gleam
+++ b/src/oas/generator/schema.gleam
@@ -518,7 +518,7 @@ pub fn to_decoder(lifted) -> l.Lookup(glance.Expression) {
         lift.Integer -> ast.access("decode", "int")
         lift.Number -> ast.access("decode", "float")
         lift.String -> ast.access("decode", "string")
-        lift.Date -> ast.access("utils", "decode_date")
+        lift.Date -> ast.call0("utils", "date_decoder")
         lift.Null -> always_decode()
         lift.Always -> ast.call0("utils", "any_decoder")
         lift.Never -> never_decode()

--- a/src/oas/generator/schema.gleam
+++ b/src/oas/generator/schema.gleam
@@ -11,7 +11,7 @@ import oas/generator/ast
 import oas/generator/lift
 import oas/generator/lookup as l
 
-/// From a dictionary of schemas generate all custom types, type aliases, encoders and decoders. 
+/// From a dictionary of schemas generate all custom types, type aliases, encoders and decoders.
 pub fn generate(schemas) {
   let #(internal, named) =
     list.map_fold(schemas |> dict.to_list, [], fn(acc, entry) {
@@ -133,6 +133,7 @@ fn to_type(lifted) -> l.Lookup(glance.Type) {
         lift.Null -> glance.NamedType("Nil", None, [])
         lift.Always -> glance.NamedType("Any", Some("utils"), [])
         lift.Never -> glance.NamedType("Never", Some("utils"), [])
+        lift.Date -> glance.NamedType("Date", Some("calendar"), [])
       }
       |> l.Done
     }
@@ -297,6 +298,7 @@ pub fn to_encoder(lifted: lift.Lifted) -> l.Lookup(glance.Expression) {
     lift.Primitive(lift.Integer) -> ast.access("json", "int") |> l.Done
     lift.Primitive(lift.Number) -> ast.access("json", "float") |> l.Done
     lift.Primitive(lift.String) -> ast.access("json", "string") |> l.Done
+    lift.Primitive(lift.Date) -> ast.access("utils", "encode_date") |> l.Done
     lift.Primitive(lift.Null) ->
       glance.Fn(
         [
@@ -516,6 +518,7 @@ pub fn to_decoder(lifted) -> l.Lookup(glance.Expression) {
         lift.Integer -> ast.access("decode", "int")
         lift.Number -> ast.access("decode", "float")
         lift.String -> ast.access("decode", "string")
+        lift.Date -> ast.access("utils", "decode_date")
         lift.Null -> always_decode()
         lift.Always -> ast.call0("utils", "any_decoder")
         lift.Never -> never_decode()

--- a/test/oas/generator_test.gleam
+++ b/test/oas/generator_test.gleam
@@ -18,6 +18,17 @@ const nullable_string = castor.String(
   False,
 )
 
+const date_string = castor.String(
+  None,
+  None,
+  None,
+  Some("date"),
+  False,
+  None,
+  None,
+  False,
+)
+
 fn object(params, required) {
   castor.Object(
     dict.from_list(params),
@@ -55,6 +66,15 @@ pub fn nil_alias_test() {
 pub fn simple_string_schema_test() {
   schema([#("my_string", castor.string())])
   |> birdie.snap(title: "simple string schema test")
+}
+
+pub fn date_format_schema_test() {
+  let parameters = [
+    #("name", castor.Inline(castor.string())),
+    #("date", castor.Inline(date_string)),
+  ]
+  schema([#("event", object(parameters, ["name", "date"]))])
+  |> birdie.snap(title: "date format schema test")
 }
 
 pub fn always_test() {


### PR DESCRIPTION
Hi there,

For my use case I would like to parse dates into gleam/time dates instead of just strings.
I would do this based on the "format" property you can specify, based on the specs linked below.
<https://spec.openapis.org/oas/v3.1.0#data-types>
<https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-7.3>

I have made a proof of concept just for dates, but we could support more of the formats specified in the spec.

Would this be something you're interested in merging?